### PR TITLE
Set ClientCredentialStyle to default value - to better support .NET 6

### DIFF
--- a/HelseId.Samples.ClientCredentials.Jwk/Program.cs
+++ b/HelseId.Samples.ClientCredentials.Jwk/Program.cs
@@ -45,7 +45,8 @@ namespace HelseId.Demo.ClientCredentials.Jwk
                     {
                         Type = ClientAssertionTypes.JwtBearer,
                         Value = BuildClientAssertion(disco, _clientId)
-                    }
+                    },
+                    ClientCredentialStyle = ClientCredentialStyle.PostBody
                 });
 
                 if (response.IsError)

--- a/HelseId.Samples.ClientCredentials/HelseId.Samples.ClientCredentials/Program.cs
+++ b/HelseId.Samples.ClientCredentials/HelseId.Samples.ClientCredentials/Program.cs
@@ -43,7 +43,8 @@ namespace HelseId.Samples.ClientCredentials
                 Address = TokenEndpoint,
                 ClientId = ClientId,
                 Scope = Scope,
-                ClientAssertion = new ClientAssertion { Value = clientAssertion, Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" }
+                ClientAssertion = new ClientAssertion { Value = clientAssertion, Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" },
+                ClientCredentialStyle = ClientCredentialStyle.PostBody
             };
 
             var result = await new HttpClient().RequestClientCredentialsTokenAsync(request);

--- a/HelseId.Samples.ClientCredentialsWithUnderenhet/Program.cs
+++ b/HelseId.Samples.ClientCredentialsWithUnderenhet/Program.cs
@@ -32,7 +32,8 @@ namespace HelseId.Samples.ClientCredentialsWithUnderenhet
                 Address = TokenEndpoint,
                 ClientId = ClientId,
                 Scope = Scope,
-                ClientAssertion = new ClientAssertion { Value = clientAssertion, Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" }
+                ClientAssertion = new ClientAssertion { Value = clientAssertion, Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" },
+                ClientCredentialStyle = ClientCredentialStyle.PostBody
             };
 
             var result = await new HttpClient().RequestClientCredentialsTokenAsync(request);

--- a/HelseId.Samples.EnterpriseCertificate/HelseId.Samples.EnterpriseCertificate/Program.cs
+++ b/HelseId.Samples.EnterpriseCertificate/HelseId.Samples.EnterpriseCertificate/Program.cs
@@ -55,7 +55,8 @@ namespace HelseId.Samples.EnterpriseCertificate
                 Address = TokenEndpoint,
                 ClientId = ClientId,
                 Scope = Scope,
-                ClientAssertion = new ClientAssertion { Value = clientAssertion, Type = IdentityModel.OidcConstants.ClientAssertionTypes.JwtBearer }
+                ClientAssertion = new ClientAssertion { Value = clientAssertion, Type = IdentityModel.OidcConstants.ClientAssertionTypes.JwtBearer },
+                ClientCredentialStyle = ClientCredentialStyle.PostBody
             };
 
             var result = await new HttpClient().RequestClientCredentialsTokenAsync(request);


### PR DESCRIPTION
In IdentityModel 4.0 the `ClientCredentialsTokenRequest`.`ClientCredentialStyle` = `ClientCredentialStyle.PostBody` as default. In version 6.0 this was changed to `ClientCredentialStyle.AuthorizationHeader`, breaking HelseIds implementation (see https://github.com/IdentityModel/IdentityModel.AspNetCore/issues/59).
This will fix the upgrade for these files.

If ClientCredentialStyle isn't set, or is set to `ClientCredentialStyle.AuthorizationHeader`, you'll get the error 
```
System.InvalidOperationException: CredentialStyle.AuthorizationHeader and client assertions are not compatible
   at IdentityModel.Client.ProtocolRequest.Prepare()
   at IdentityModel.Client.HttpClientTokenRequestExtensions.RequestTokenAsync(HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken)
   at IdentityModel.Client.HttpClientTokenRequestExtensions.RequestClientCredentialsTokenAsync(HttpMessageInvoker client, ClientCredentialsTokenRequest request, CancellationToken cancellationToken)
   at HelseId.Demo.ClientCredentials.Jwk.Program.Main(String[] args)
```

With .NET 6 it looks like it's recommended to use IdentityModel 6, and this will make it easy to upgrade :) 