### PR TITLE
Add credential style PostBody to token exchange sample

### DIFF
--- a/HelseId.Samples.TokenExchangeDemo/HelseId.TokenExchangeDemo/Program.cs
+++ b/HelseId.Samples.TokenExchangeDemo/HelseId.TokenExchangeDemo/Program.cs
@@ -107,6 +107,7 @@ namespace HelseId.RefreshTokenDemo
                     Type = OidcConstants.ClientAssertionTypes.JwtBearer,
                     Value = BuildClientAssertion(ActorClientId, _discoveryDocument, GetEnterpriseCertificateSecurityKey())
                 },
+                ClientCredentialStyle = ClientCredentialStyle.PostBody,
                 ClientId = ActorClientId,
                 Scope = "e-helse:nasjonalt_api/scope",
                 SubjectToken = subjectToken,


### PR DESCRIPTION
This is an addon to PR #9.

This sets `ClientCredentialStyle = ClientCredentialStyle.PostBody` for the token exchange sample.
This makes the sample code work with .NET 6 and IdentityModel 6.0.

I haven't done any testing with this sample code. I could not get the sample to run.

I have tested adding `ClientCredentialStyle = ClientCredentialStyle.PostBody` to our own code with .NET 6 and IdentityModel 6.0 which does token exchange with https://helseid-sts.test.nhn.no/. That worked fine.

Is there any more testing that should be done?