### PR TITLE
Include 'alg' in generated JWK

### DIFF
--- a/HelseId.RsaJwk/HelseId.RsaJwk.csproj
+++ b/HelseId.RsaJwk/HelseId.RsaJwk.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/HelseId.RsaJwk/JsonWebKey.cs
+++ b/HelseId.RsaJwk/JsonWebKey.cs
@@ -15,6 +15,7 @@
         public string X { get; set; }
         public string Y { get; set; }
         public string Kid { get; set; }
-        public string Use { get; set; } 
+        public string Use { get; set; }
+        public string Alg { get; set; }
     }
 }

--- a/HelseId.RsaJwk/Options.cs
+++ b/HelseId.RsaJwk/Options.cs
@@ -1,0 +1,21 @@
+
+using CommandLine;
+
+namespace HelseId.RsaJwk;
+
+public class Options
+{
+    [Option('t', "key-type", Required = true, HelpText = "Supported types: RSA, EC")]
+    public KeyType KeyType { get; set; }
+
+    [Option('p', "prefix", HelpText = "Optional prefix for the generated JWK files.")]
+    public string Prefix { get; set; }
+
+    [Option('a', "alg", HelpText = "Algorithm intended for use with the key. Defaults to RS512 for RSA, and ES256 for ECDSA")]
+    public string Alg { get; set; }
+}
+
+public enum KeyType {
+    Rsa,
+    Ec,
+}

--- a/HelseId.RsaJwk/Options.cs
+++ b/HelseId.RsaJwk/Options.cs
@@ -13,9 +13,13 @@ public class Options
 
     [Option('a', "alg", HelpText = "Algorithm intended for use with the key. Defaults to RS512 for RSA, and ES256 for ECDSA")]
     public string Alg { get; set; }
+
+    [Option('s', "rsa-size", HelpText = "Key size in bits for RSA key. Default 4096. Min 2048.")]
+    public int? RsaKeySize { get; set; }
 }
 
-public enum KeyType {
+public enum KeyType
+{
     Rsa,
     Ec,
 }

--- a/HelseId.RsaJwk/Program.cs
+++ b/HelseId.RsaJwk/Program.cs
@@ -29,6 +29,12 @@ namespace HelseId.RsaJwk
 
         private static int GenerateKey(Options options)
         {
+            if (options.RsaKeySize < 2048)
+            {
+                Console.WriteLine("RSA key size must be at least 2048");
+                return 1;
+            }
+
             var keyType = options.KeyType;
             var prefix = options.Prefix;
 
@@ -52,8 +58,7 @@ namespace HelseId.RsaJwk
             switch (keyType)
             {
                 case KeyType.Rsa:
-                    const int rsaKeySize = 4096;
-                    (privateJwk, publicJwk) = GenerateRsaKey(rsaKeySize, options);
+                    (privateJwk, publicJwk) = GenerateRsaKey(options);
                     break;
                 case KeyType.Ec:
                     (privateJwk, publicJwk) = GenerateEcdsaKey(options);
@@ -71,8 +76,9 @@ namespace HelseId.RsaJwk
             return 0;
         }
 
-        private static (JsonWebKey privateJwk, JsonWebKey publicJwk) GenerateRsaKey(int keySize, Options options)
+        private static (JsonWebKey privateJwk, JsonWebKey publicJwk) GenerateRsaKey(Options options)
         {
+            var keySize = options.RsaKeySize ?? 4096;
             var key = RSA.Create(keySize);
             var securityKey = new RsaSecurityKey(key);
             securityKey.KeyId = Guid.NewGuid().ToString().Replace("-", string.Empty);


### PR DESCRIPTION
'alg' is required by Maskinporten.

Benytter CommandLineParser for å gjøre parsing av argumenter lettere.